### PR TITLE
Fix BlockReader test initialization

### DIFF
--- a/packages/gaia-core/src/rom/extraction/__tests__/BlockReader.test.ts
+++ b/packages/gaia-core/src/rom/extraction/__tests__/BlockReader.test.ts
@@ -1,14 +1,20 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { OpCode, ALL_OPCODES, GROUPED_OPCODES, OpCodeUtils } from '../OpCode';
 import { AddressingMode, DbRootUtils } from 'gaia-shared';
 import { BlockReader } from '../blocks';
 
+
 describe('BlockReader', () => {
+  let reader: BlockReader;
 
-    const data = [];
-    const dbRoot = DbRootUtils.fromFolder("../../../../../../ext/GaiaLib/db", "../../../../../../ext/GaiaLib/db/snes");
-
-    const reader = new BlockReader(data, dbRoot);
+  beforeAll(async () => {
+    const data = new Uint8Array();
+    const dbRoot = await DbRootUtils.fromFolder(
+      '../../ext/GaiaLib/db/us',
+      '../../ext/GaiaLib/db/snes'
+    );
+    reader = new BlockReader(data, dbRoot);
+  });
 
   describe('BlockReader class', () => {
     it('should create a block reader with correct properties', () => {


### PR DESCRIPTION
## Summary
- fix async loading in `BlockReader.test.ts`
- load database from the correct subfolder

## Testing
- `pnpm run test --filter ./packages/gaia-core` *(fails: Unknown OpCode)*

------
https://chatgpt.com/codex/tasks/task_e_68796d2358488332abb773f933913218