### PR TITLE
Fix QuintetLZ path in mapping

### DIFF
--- a/GAIALIB_TYPESCRIPT_MAPPING.md
+++ b/GAIALIB_TYPESCRIPT_MAPPING.md
@@ -152,7 +152,7 @@ GaiaLib is a comprehensive C# library for ROM modification of Illusion of Gaia. 
 | C# File | TypeScript Destination | Notes |
 |---------|----------------------|-------|
 | `Compression/ICompressionProvider.cs` | `gaia-core/src/compression/interface.ts` | Compression interface |
-| `Compression/QuintetLZ.cs` | `gaia-core/src/compression/quintet-lz.ts` | QuintetLZ algorithm |
+| `Compression/QuintetLZ.cs` | `gaia-core/src/compression/QuintetLZ.ts` | QuintetLZ algorithm |
 
 ### 6. Sprite Handling
 


### PR DESCRIPTION
## Summary
- update compression mapping to use correct `QuintetLZ.ts` path

## Testing
- `pnpm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68797021891c8332b9922cbc24e2a87a