### PR TITLE
Fix assembly output differences

### DIFF
--- a/docs/AssemblyComparison.md
+++ b/docs/AssemblyComparison.md
@@ -1,0 +1,56 @@
+# Assembly Output Comparison
+
+This document summarizes differences observed between the C# disassembly and the current TypeScript output for the `sE6_gaia` scene.
+
+## Missing COP parameters
+The C# output shows each `COP` instruction with its full parameter list, for example:
+
+```
+COP [D9] ( #$0000, &code_list_08D7E2 )
+```
+
+from lines 118‑126 of `sE6_gaia(C#).asm`.
+However, the TypeScript output lacks these operands and only prints the opcode:
+
+```
+COP [D9]
+```
+
+(from lines 96‑104 of `sE6_gaia(TS).asm`).
+This indicates that `CopCommandProcessor.parseCopCommand` is not attaching
+parsed operands to the operation.
+
+## Rewritten literals
+Numerous immediate values in the TypeScript file are replaced by label
+expressions such as `@BMP_000000+4` instead of simple hex literals. Example:
+
+```
+CMP #$@BMP_000000+4
+```
+
+(from line 19 of the TypeScript file) vs.
+
+```
+CMP #$0004
+```
+
+(from line 26 of the C# file).
+These substitutions come from the transform logic during reference
+resolution and differ from the C# disassembly.
+
+## Missing include directives
+The C# version begins with several `?INCLUDE` statements which are absent in
+the TypeScript output. This suggests the block writer is not emitting
+includes from the block metadata.
+
+## Suggested areas to inspect
+- Ensure `CopCommandProcessor` receives the correct `CopDef` for each opcode
+  and pushes all parsed operands before `AsmReader` constructs the `Op`.
+- Review the transform application in `TransformProcessor` and
+  `ReferenceManager.resolveName` to avoid rewriting small constants into
+  labels when the C# version uses raw numbers.
+- Verify `BlockWriter.writeBlocks` writes each block's include list at the
+  top of the output file.
+
+Addressing these points should help align the TypeScript disassembly with
+the C# reference output.

--- a/packages/gaia-core/src/rom/extraction/asm.ts
+++ b/packages/gaia-core/src/rom/extraction/asm.ts
@@ -60,12 +60,18 @@ export class AsmReader {
     // Apply label transforms to operands after processing. This ensures that the ROM state is processed and valid.
     this._transformProcessor.applyTransforms(operationContext.xForm1, operationContext.xForm2, operands);
 
-    return new Op(
+    const op = new Op(
       code,
       opStart,
       operands,
       this._romDataReader.position - opStart
     );
+
+    if (operationContext.copDef) {
+      op.copDef = operationContext.copDef;
+    }
+
+    return op;
   }
 
   /**

--- a/packages/gaia-core/src/rom/extraction/writer.ts
+++ b/packages/gaia-core/src/rom/extraction/writer.ts
@@ -212,6 +212,9 @@ export class BlockWriter {
 
   private resolveOperand(op: Op, obj: any, isBranch: boolean = false): any {
     if (typeof obj === 'number') {
+      if (op.code.mode === AddressingMode.Immediate) {
+        return obj;
+      }
       return this._blockReader.resolveName(obj, AddressType.Address, isBranch);
     }
     if (this.getObjectType(obj) === ObjectType.LocationWrapper) {

--- a/packages/gaia-shared/src/database/root.ts
+++ b/packages/gaia-shared/src/database/root.ts
@@ -98,6 +98,9 @@ export class DbRootUtils {
     // Process blocks and parts
     for (const block of blocks) {
       block.parts = parts.filter(p => p.block === block.name);
+      for (const part of block.parts) {
+        (part as any)._block = block;
+      }
     }
 
     const cfg = config[0];


### PR DESCRIPTION
## Summary
- preserve COP parameters when parsing assembly
- avoid resolving immediate constants to labels
- connect parts to their blocks so includes emit correctly

## Testing
- `pnpm run check-all` *(fails: turbo/ESLint issues)*
- `pnpm run test` *(fails: no test files)*

------
https://chatgpt.com/codex/tasks/task_e_687977c127a4833292aab1986ba57143