### PR TITLE
Add Byte and Word operand helpers

### DIFF
--- a/packages/gaia-core/src/rom/extraction/writer.ts
+++ b/packages/gaia-core/src/rom/extraction/writer.ts
@@ -260,6 +260,9 @@ export class BlockWriter {
 
     // Check for explicit type tags first
     if (obj._tag) {
+      if (obj._tag === 'Byte' || obj._tag === 'Word') {
+        return ObjectType.TypedNumber;
+      }
       return obj._tag as ObjectType;
     }
 
@@ -351,7 +354,7 @@ export class BlockWriter {
         return this.writeNumber(obj as number);
 
       case ObjectType.TypedNumber:
-        return this.writeTypedNumber(obj as TypedNumber);
+        return this.writeTypedNumber(obj as any);
 
       case ObjectType.String:
         return [String(obj)];
@@ -584,11 +587,15 @@ export class BlockWriter {
     }
   }
 
-  private writeTypedNumber(num: TypedNumber): string[] {
-    if (num.size === 1) {
-      return [`#$${num.value.toString(16).toUpperCase().padStart(2, '0')}`];
+  private writeTypedNumber(num: TypedNumber | { _tag: string; value: number }): string[] {
+    let size = 1;
+    if ('size' in num) {
+      size = (num as TypedNumber).size;
+    } else if (num._tag === 'Word') {
+      size = 2;
     }
-    const width = num.size * 2;
+
+    const width = size * 2;
     return [`#$${num.value.toString(16).toUpperCase().padStart(width, '0')}`];
   }
 

--- a/packages/gaia-shared/src/types/constants.ts
+++ b/packages/gaia-shared/src/types/constants.ts
@@ -29,8 +29,18 @@ export class RomProcessingConstants {
    * @throws Error when unable to determine size
    */
   public static getSize(obj: unknown): number {
-    if (obj && typeof obj === 'object' && 'size' in obj) {
-      return (obj as { size: number }).size;
+    if (obj && typeof obj === 'object') {
+      if ('size' in obj) {
+        return (obj as { size: number }).size;
+      }
+      if ('_tag' in obj) {
+        switch ((obj as { _tag: string })._tag) {
+          case 'Byte':
+            return 1;
+          case 'Word':
+            return 2;
+        }
+      }
     } else if (obj instanceof Uint8Array) {
       return obj.length;
     } else if (typeof obj === 'number') {

--- a/packages/gaia-shared/src/types/operands.ts
+++ b/packages/gaia-shared/src/types/operands.ts
@@ -4,6 +4,20 @@ export interface TypedNumber {
   size: number; // byte size
 }
 
+export interface Byte {
+  _tag: 'Byte';
+  value: number;
+}
+
+export interface Word {
+  _tag: 'Word';
+  value: number;
+}
+
 export function createTypedNumber(value: number, size: number): TypedNumber {
   return { _tag: 'TypedNumber', value, size };
 }
+
+export const createByte = (v: number): Byte => ({ _tag: 'Byte', value: v & 0xff });
+
+export const createWord = (v: number): Word => ({ _tag: 'Word', value: v & 0xffff });


### PR DESCRIPTION
## Summary
- add Byte and Word operand interfaces and creators
- support new operand tags in `getSize`
- handle Byte/Word objects when formatting assembly output

## Testing
- `pnpm type-check` *(fails: referenced projects missing composite flag)*
- `pnpm test` *(fails: no test files found)*
- `pnpm build --filter=gaia-core`
- `pnpm build --filter=gaia-shared`


------
https://chatgpt.com/codex/tasks/task_e_687a5ddc0bd88332aab818fee1fd2df4