### PR TITLE
Use typed operands

### DIFF
--- a/packages/gaia-core/src/rom/extraction/addressing.ts
+++ b/packages/gaia-core/src/rom/extraction/addressing.ts
@@ -1,5 +1,14 @@
 import { OpCode, Registers } from '../../assembly';
-import { AddressingMode, AddressType, AddressSpace, Address, LocationWrapper, StatusFlags } from 'gaia-shared';
+import {
+  AddressingMode,
+  AddressType,
+  AddressSpace,
+  Address,
+  LocationWrapper,
+  StatusFlags,
+  createByte,
+  createWord,
+} from 'gaia-shared';
 import { RomDataReader } from './reader';
 import { StackOperations } from './stack';
 import { TransformProcessor } from './transforms';
@@ -105,27 +114,34 @@ export class AddressingModeHandler {
     this.updateRegisterForImmediateInstruction(mnemonic, operand, reg);
   }
 
-  private readImmediateOperand(size: number): number {
-    return size === 3 ? this._dataReader.readUShort() : this._dataReader.readByte();
+  private readImmediateOperand(size: number) {
+    return size === 3
+      ? createWord(this._dataReader.readUShort())
+      : createByte(this._dataReader.readByte());
   }
 
-  private updateRegisterForImmediateInstruction(mnemonic: string, operand: number, reg: Registers): void {
+  private updateRegisterForImmediateInstruction(
+    mnemonic: string,
+    operand: number | { value: number },
+    reg: Registers
+  ): void {
+    const value = typeof operand === 'number' ? operand : operand.value;
     switch (mnemonic) {
       case 'LDA':
-        reg.accumulator = this.calculateRegisterValue(reg.accumulator, operand);
+        reg.accumulator = this.calculateRegisterValue(reg.accumulator, value);
         break;
 
       case 'LDX':
-        reg.xIndex = this.calculateRegisterValue(reg.xIndex, operand);
+        reg.xIndex = this.calculateRegisterValue(reg.xIndex, value);
         break;
 
       case 'LDY':
-        reg.yIndex = this.calculateRegisterValue(reg.yIndex, operand);
+        reg.yIndex = this.calculateRegisterValue(reg.yIndex, value);
         break;
 
       case 'SEP':
       case 'REP':
-        this.updateStatusFlags(mnemonic, operand);
+        this.updateStatusFlags(mnemonic, value);
         break;
     }
   }

--- a/packages/gaia-core/src/rom/extraction/cop.ts
+++ b/packages/gaia-core/src/rom/extraction/cop.ts
@@ -1,6 +1,14 @@
 import { RomDataReader } from './reader';
-import { Address, AddressType, AddressSpace, LocationWrapper, MemberType, createTypedNumber } from 'gaia-shared';
-import type { CopDef, TypedNumber } from 'gaia-shared';
+import {
+  Address,
+  AddressType,
+  AddressSpace,
+  LocationWrapper,
+  MemberType,
+  createByte,
+  createWord,
+} from 'gaia-shared';
+import type { CopDef } from 'gaia-shared';
 import type { DbRoot } from 'gaia-shared';
 import type { BlockReader } from './blocks';
 
@@ -76,17 +84,17 @@ export class CopCommandProcessor {
   }
 
   private readMemberTypeValue(
-    memberType: MemberType, 
-    partStr: string, 
-    isPtr: boolean, 
-    referenceType: string, 
+    memberType: MemberType,
+    partStr: string,
+    isPtr: boolean,
+    referenceType: string,
     addrType: AddressType
   ): unknown {
     switch (memberType) {
       case MemberType.Byte:
-        return createTypedNumber(this._romDataReader.readByte(), 1);
+        return createByte(this._romDataReader.readByte());
       case MemberType.Word:
-        return createTypedNumber(this._romDataReader.readUShort(), 2);
+        return createWord(this._romDataReader.readUShort());
       case MemberType.Offset:
         return this.createCopLocation(this._romDataReader.readUShort(), null, partStr, isPtr, referenceType, addrType);
       case MemberType.Address:

--- a/packages/gaia-core/src/rom/extraction/parser.ts
+++ b/packages/gaia-core/src/rom/extraction/parser.ts
@@ -2,7 +2,17 @@ import { Op, Registers } from '../../assembly';
 import { RomDataReader } from './reader';
 import { StringReader } from './strings';
 import { ReferenceManager } from './references';
-import { Address, AddressSpace, AddressType, DbBlockUtils, LocationWrapper, MemberType, StructDef } from 'gaia-shared';
+import {
+  Address,
+  AddressSpace,
+  AddressType,
+  DbBlockUtils,
+  LocationWrapper,
+  MemberType,
+  StructDef,
+  createByte,
+  createWord,
+} from 'gaia-shared';
 import type { DbRoot, DbBlock, DbPart } from 'gaia-shared';
 import type { DbStruct } from 'gaia-shared';
 import type { DbStringType } from 'gaia-shared';
@@ -50,9 +60,9 @@ export class TypeParser {
     if (mType !== null) {
       switch (mType) {
         case MemberType.Byte:
-          return this._romDataReader.readByte();
+          return createByte(this._romDataReader.readByte());
         case MemberType.Word:
-          return this.parseWordSafe();
+          return createWord(this.parseWordSafe() as number);
         case MemberType.Offset:
           return this.parseLocation(this._romDataReader.readUShort(), bank, null, AddressType.Offset);
         case MemberType.Address:


### PR DESCRIPTION
## Summary
- use `createByte` and `createWord` when reading typed data
- return typed operands for immediates
- update COP processor to build typed values

## Testing
- `pnpm --filter gaia-core type-check`
- `pnpm --filter gaia-core test` *(fails: Unknown OpCode)*

------
https://chatgpt.com/codex/tasks/task_e_687a675dc37083328a81ed2bf2330a5c