### PR TITLE
Fix CopDef typing in OperationContext

### DIFF
--- a/packages/gaia-core/src/rom/extraction/addressing.ts
+++ b/packages/gaia-core/src/rom/extraction/addressing.ts
@@ -13,7 +13,7 @@ import { RomDataReader } from './reader';
 import { StackOperations } from './stack';
 import { TransformProcessor } from './transforms';
 import { CopCommandProcessor } from './cop';
-import type { DbRoot } from 'gaia-shared';
+import type { DbRoot, CopDef } from 'gaia-shared';
 import type { BlockReader } from './blocks';
 
 /**
@@ -25,7 +25,7 @@ export class OperationContext {
   public nextAddress: number = 0;
   public xForm1: string | null = null;
   public xForm2: string | null = null;
-  public copDef: any = null;
+  public copDef: CopDef | null = null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- import `CopDef` in the addressing handler
- type `OperationContext.copDef` as `CopDef | null`

## Testing
- `pnpm test` in `packages/gaia-core`
- `pnpm type-check` in `packages/gaia-core`


------
https://chatgpt.com/codex/tasks/task_e_6885c91056388332904bcd478e1219f7