### PR TITLE
Add gaia-core README

### DIFF
--- a/packages/gaia-core/README.md
+++ b/packages/gaia-core/README.md
@@ -1,0 +1,27 @@
+# gaia-core
+
+Core ROM processing engine for the GaiaLabs platform.
+
+This package exposes TypeScript libraries for reading, writing and rebuilding ROMs. It runs in both Node.js and the browser and is referenced by the studio and API applications.
+
+See the [project root README](../../README.md) for an overview of the monorepo.
+
+## Directory overview
+
+- `assembly/` – CPU opcode helpers and stack/register utilities.
+- `compression/` – compression providers such as `QuintetLZ` with tests.
+- `rom/` – project parsing, extraction and rebuild pipeline.
+- `sprites/` – sprite map and frame helpers.
+- `api/` – high-level `ProjectManager` and `RomProcessor` classes.
+- `__tests__/` – vitest unit tests.
+
+## Common commands
+
+```bash
+pnpm dev          # build in watch mode with tsup
+pnpm build        # output ESM/CJS bundles
+pnpm test         # run unit tests with vitest
+pnpm type-check   # run the TypeScript compiler
+```
+
+The original C# implementation lives under `ext/GaiaLib` and serves as a reference.

--- a/packages/gaia-core/package.json
+++ b/packages/gaia-core/package.json
@@ -7,7 +7,8 @@
   "browser": "dist/browser.js",
   "module": "dist/index.mjs",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## Summary
- add documentation describing gaia-core
- publish README in npm package

## Testing
- `pnpm -w test --filter gaia-core`

------
https://chatgpt.com/codex/tasks/task_e_6885c915f29883329b11a3a4d4e59f74