### PR TITLE
ci: deploy gaia-translator on changes

### DIFF
--- a/.github/workflows/deploy-translator.yml
+++ b/.github/workflows/deploy-translator.yml
@@ -1,0 +1,30 @@
+name: Deploy gaia-translator
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - 'apps/gaia-translator/**'
+      - '.github/workflows/deploy-translator.yml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter gaia-translator deploy
+        env:
+          SFTP_HOST: ${{ secrets.SFTP_HOST }}
+          SFTP_PORT: ${{ secrets.SFTP_PORT }}
+          SFTP_USERNAME: ${{ secrets.SFTP_USERNAME }}
+          SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
+          SFTP_REMOTE_PATH: ${{ secrets.SFTP_REMOTE_PATH }}


### PR DESCRIPTION
## Summary
- deploy gaia-translator to FTPS when packages or the app change

## Testing
- `npx prettier --check .github/workflows/deploy-translator.yml`
- `pnpm --filter gaia-translator lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68914cdde0588332b908ee7934b5d931