### PR TITLE
Fix translator build by adding supabase client and API stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ out/
 .next/
 lib/
 !/packages/gaia-ui/src/lib/
+!/apps/gaia-translator/src/lib/
 
 # Development
 .env.local

--- a/apps/gaia-translator/src/lib/api.ts
+++ b/apps/gaia-translator/src/lib/api.ts
@@ -1,0 +1,55 @@
+import { supabase } from './supabase';
+import type {
+  Chapter,
+  SceneGroup,
+  Scene,
+  File,
+  UIGameString,
+  TextRegion
+} from '../types/database';
+
+export async function fetchChapters(): Promise<Chapter[]> {
+  const { data } = await supabase.from('Chapter').select('*');
+  return (data as Chapter[]) || [];
+}
+
+export async function fetchSceneGroups(): Promise<SceneGroup[]> {
+  const { data } = await supabase.from('SceneGroup').select('*');
+  return (data as SceneGroup[]) || [];
+}
+
+export async function fetchScenes(groupId?: string): Promise<Scene[]> {
+  let query = supabase.from('Scene').select('*');
+  if (groupId) {
+    query = query.eq('groupId', groupId);
+  }
+  const { data } = await query;
+  return (data as Scene[]) || [];
+}
+
+export async function fetchFiles(sceneId?: string): Promise<File[]> {
+  let query = supabase.from('File').select('*');
+  if (sceneId) {
+    query = query.eq('sceneId', sceneId);
+  }
+  const { data } = await query;
+  return (data as File[]) || [];
+}
+
+export interface GameStringFilter {
+  selectedChapter?: string;
+  selectedGroup?: string;
+  selectedScene?: string;
+  selectedFile?: string;
+  searchQuery?: string;
+}
+
+export async function fetchGameStrings(_filter: GameStringFilter = {}): Promise<UIGameString[]> {
+  const { data } = await supabase.from('GameString').select('*');
+  return (data as UIGameString[]) || [];
+}
+
+export async function fetchTextRegions(): Promise<TextRegion[]> {
+  const { data } = await supabase.from('TextRegion').select('*');
+  return (data as TextRegion[]) || [];
+}

--- a/apps/gaia-translator/src/lib/supabase.ts
+++ b/apps/gaia-translator/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = (import.meta as any).env.VITE_SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
+const supabaseAnonKey = (import.meta as any).env.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY || '';
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/apps/gaia-translator/src/pages/GameScriptEditor.tsx
+++ b/apps/gaia-translator/src/pages/GameScriptEditor.tsx
@@ -121,7 +121,7 @@ const GameScriptEditor = () => {
 
         // Set default region if available
         if (textRegionsData.length > 0) {
-          const coreRegion = textRegionsData.find(r => r.isCore);
+          const coreRegion = textRegionsData.find((r: TextRegion) => r.isCore);
           if (coreRegion && selectedRegion === 'NA-English') {
             setSelectedRegion(coreRegion.code);
           }

--- a/apps/gaia-translator/tsconfig.json
+++ b/apps/gaia-translator/tsconfig.json
@@ -23,6 +23,7 @@
     "**/*.tsx",
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "prisma"
   ]
 }


### PR DESCRIPTION
## Summary
- add Supabase client and API helpers for gaia-translator
- type default region lookup to satisfy strict checks
- exclude Prisma directory from translator TypeScript build and adjust gitignore

## Testing
- `pnpm run translator:build`
- `pnpm --filter gaia-translator run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6891665ee46c8332a2bc2407570fbcdd