### PR TITLE
fix: load supabase env vars

### DIFF
--- a/apps/gaia-translator/src/lib/supabase.ts
+++ b/apps/gaia-translator/src/lib/supabase.ts
@@ -1,6 +1,17 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = (import.meta as any).env.VITE_SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
-const supabaseAnonKey = (import.meta as any).env.VITE_SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY || '';
+const supabaseUrl =
+  (import.meta as any).env.SUPABASE_URL ||
+  (import.meta as any).env.VITE_SUPABASE_URL ||
+  process.env.SUPABASE_URL ||
+  process.env.VITE_SUPABASE_URL ||
+  '';
+
+const supabaseAnonKey =
+  (import.meta as any).env.SUPABASE_ANON_KEY ||
+  (import.meta as any).env.VITE_SUPABASE_ANON_KEY ||
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  '';
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/apps/gaia-translator/src/vite-env.d.ts
+++ b/apps/gaia-translator/src/vite-env.d.ts
@@ -1,13 +1,15 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_SUPABASE_URL: string
-  readonly VITE_SUPABASE_ANON_KEY: string
-  readonly VITE_API_URL: string
-  readonly VITE_COMMUNITY_URL: string
+  readonly SUPABASE_URL: string;
+  readonly SUPABASE_ANON_KEY: string;
+  readonly VITE_SUPABASE_URL?: string;
+  readonly VITE_SUPABASE_ANON_KEY?: string;
+  readonly VITE_API_URL: string;
+  readonly VITE_COMMUNITY_URL: string;
   // Add more environment variables as needed
 }
 
 interface ImportMeta {
-  readonly env: ImportMetaEnv
+  readonly env: ImportMetaEnv;
 }


### PR DESCRIPTION
## Summary
- ensure Supabase client reads SUPABASE_URL and SUPABASE_ANON_KEY from env, falling back to VITE_ prefixed variables
- update Vite env typings for new variables

## Testing
- `pnpm translator:build`


------
https://chatgpt.com/codex/tasks/task_e_6892a0c934608332a3a1ed8210c72f04