### PR TITLE
chore(ui): convert tailwind config to esm

### DIFF
--- a/packages/gaia-ui/tailwind.config.js
+++ b/packages/gaia-ui/tailwind.config.js
@@ -1,5 +1,7 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+import tailwindcssAnimate from "tailwindcss-animate";
+
+export default {
   darkMode: ["class"],
   content: [
     './src/**/*.{ts,tsx}',
@@ -165,5 +167,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 };


### PR DESCRIPTION
## Summary
- convert gaia-ui tailwind config to ESM and import plugin via ES module

## Testing
- `cd packages/gaia-ui && pnpm build`
- `cd packages/gaia-ui && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689326cb977c8332b5e0fbe02a0321f3